### PR TITLE
Swap psutil for tasklist to get windows building.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ phf = { version = "0.11.1", features = ["macros"] }
 jwalk = "0.8.1"
 # home = "0.5.3"
 quit = "2.0.0"
-psutil = "3.2.2"
 regex = "1.7.1"
 serde_json = "1.0.108"
 tantivy = "0.21.1"
@@ -35,4 +34,8 @@ tantivy = "0.21.1"
 target = "x86_64-unknown-linux-gnu"
 
 [target.x86_64-unknown-linux-gnu]
+psutil = "3.2.2"
 linker = "/usr/local/bin/x86_64-unknown-linux-gnu-gcc"
+
+[target.'cfg(windows)'.dependencies]
+tasklist = "0.2.13"

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -24,6 +24,8 @@ export async function activate(_context: ExtensionContext) {
     // Apple/Intel
       command = `${base_dir}/bin/fuzzy`;
     }
+  } else if ("windows") {
+    command = `${base_dir}/bin/fuzzy.exe`;
   } else {
     command = `${base_dir}/bin/fuzzy_x86_64-unknown-linux-gnu`;
   }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.0.0",
     "@types/node": "^12.12.0",
-    "@types/vscode": "^1.44.0",
+    "@types/vscode": "^1.84.2",
     "@typescript-eslint/eslint-plugin": "^3.8.0",
     "@typescript-eslint/parser": "^3.8.0",
     "cross-env": "^7.0.2",
@@ -97,6 +97,8 @@
     "ts-loader": "^8.0.12",
     "typescript": "^4.4.3",
     "vscode-test": "^1.4.0",
-    "vscode-uri": "^3.0.2"
+    "vscode-uri": "^3.0.2",
+    "vscode": "^1.1.37",
+    "vscode-languageclient": "^9.0.1"
   }
 }


### PR DESCRIPTION
Shifted around the cargo.toml and added a new dependency to get around the lack of windows support with psutil. 

Tasklist is a win32 api wrapper that handles process ids and is swapped in as a comp-time drop in replacement. 

My knowledge of rust and especially the cargo.toml is limited so I may have broken something on the linux/macos side of builds especially since I do not have a macos system live and ready nor a large enough ruby code base to try it out. 

Built on Win11